### PR TITLE
Small bug fix and a small feature addition

### DIFF
--- a/kiwix.el
+++ b/kiwix.el
@@ -216,6 +216,8 @@ Set it to ‘t’ will use Emacs built-in ‘completing-read’."
   "Specify kiwix-mode keybinding prefix before loading."
   :type 'kbd)
 
+(defvar kiwix--server-process nil
+  "Local server process launched by ‘kiwix-launch-server’.")
 
 ;; launch Kiwix server
 ;;;###autoload
@@ -236,13 +238,21 @@ Set it to ‘t’ will use Emacs built-in ‘completing-read’."
                       "-p" (format "%s:80" kiwix-server-port)
                       "kiwix/kiwix-serve"
                       "--library" "library.xml"))
-      ('kiwix-serve-local (start-process
-                           "kiwix-server"
-                           " *kiwix server*"
-                           kiwix-server-command
-                           "--port" (number-to-string kiwix-server-port)
-                           "--daemon"
-                           "--library" (concat library-path "library.xml"))))))
+      ('kiwix-serve-local
+       (setq kiwix--server-process
+             (start-process
+              "kiwix-server"
+              " *kiwix server*"
+              kiwix-server-command
+              "--port" (number-to-string kiwix-server-port)
+              "--library" (concat kiwix-zim-dir "library.xml")))))))
+
+(defun kiwix-stop-local-server ()
+  "Stops a Kiwix server started by ‘kiwix-launch-server’."
+  (interactive)
+  (when kiwix--server-process
+    (kill-process kiwix--server-process)
+    (setq kiwix--server-process nil)))
 
 (defun kiwix-capitalize-first (string)
   "Only capitalize the first word of STRING."

--- a/kiwix.el
+++ b/kiwix.el
@@ -222,7 +222,7 @@ Set it to ‘t’ will use Emacs built-in ‘completing-read’."
 (defun kiwix-launch-server ()
   "Launch Kiwix server."
   (interactive)
-  (let ((library-path kiwix-default-library-dir))
+  (let ((library-path kiwix-zim-dir))
     (cl-case kiwix-server-type
       ('docker-remote
        (message "kiwix-serve service is started by user manually at other place."))

--- a/kiwix.el
+++ b/kiwix.el
@@ -79,7 +79,7 @@
       (expand-file-name "~/.www.kiwix.org/kiwix")
       (car (directory-files (expand-file-name "~/.www.kiwix.org/kiwix") nil ".*\\.default\\'")) ; profile folder name
       "/data/library/*.zim")))
-  "The kiwix ZIM files directory.  Must end with a slash."
+  "The kiwix ZIM files directory."
   :type 'string
   :safe #'stringp)
 

--- a/kiwix.el
+++ b/kiwix.el
@@ -79,7 +79,7 @@
       (expand-file-name "~/.www.kiwix.org/kiwix")
       (car (directory-files (expand-file-name "~/.www.kiwix.org/kiwix") nil ".*\\.default\\'")) ; profile folder name
       "/data/library/*.zim")))
-  "The kiwix ZIM files directory."
+  "The kiwix ZIM files directory.  Must end with a slash."
   :type 'string
   :safe #'stringp)
 

--- a/kiwix.el
+++ b/kiwix.el
@@ -245,7 +245,7 @@ Set it to ‘t’ will use Emacs built-in ‘completing-read’."
               " *kiwix server*"
               kiwix-server-command
               "--port" (number-to-string kiwix-server-port)
-              "--library" (concat kiwix-zim-dir "library.xml")))))))
+              "--library" (concat kiwix-zim-dir "/library.xml")))))))
 
 (defun kiwix-stop-local-server ()
   "Stops a Kiwix server started by ‘kiwix-launch-server’."


### PR DESCRIPTION
Hi there,
While setting this package up earlier, I found that the code for launching a server locally was broken, as `kiwix-launch-server` was referring to an undefined variable named `kiwix-default-library-dir`.  I have changed that reference to `kiwix-zim-dir`.  That function was also failing to add a slash between the directory and file name when specifying the path to the library file when creating a local Kiwix server, so I have added one.  I also thought it would be useful to allow stopping the server that this package starts, so I removed the `--daemon` option from the handler for the `'kiwix-serve-local` case, stored a reference to the server process in a variable, and have added a new command to stop the server process, `kiwix-stop-local-server`.  I hope that at least the bug fixes can be merged, if you don't agree that the server should be able to be stopped I can remove that from this PR.  Also, I don't know how you check this, but I have completed the FSF copyright assignment paperwork for Emacs.

Thanks a lot for this package,
Matt