### PR TITLE
Save the library list when fetching from a local server

### DIFF
--- a/kiwix.el
+++ b/kiwix.el
@@ -204,8 +204,9 @@ Set it to ‘t’ will use Emacs built-in ‘completing-read’."
    ((or (eq kiwix-server-type 'kiwix-serve-local)
         (eq kiwix-server-type 'docker-local))
     (when (and (file-directory-p kiwix-zim-dir) (file-readable-p kiwix-zim-dir))
-      (mapcar #'kiwix--get-library-name
-              (directory-files kiwix-zim-dir nil ".*\\.zim\\'"))))))
+      (setq kiwix-libraries
+            (mapcar #'kiwix--get-library-name
+                    (directory-files kiwix-zim-dir nil ".*\\.zim\\'")))))))
 
 (defun kiwix-select-library (&optional filter)
   "Select Kiwix library name."


### PR DESCRIPTION
When using a Docker server, `setq kiwix-libraries` is called to save the result of fetching the library list, however that wasn't being done for local servers.